### PR TITLE
[codex] Stretch soycluster control plane for node loss

### DIFF
--- a/inventory/soycluster/group_vars/k8s_cluster/addons.yml
+++ b/inventory/soycluster/group_vars/k8s_cluster/addons.yml
@@ -224,15 +224,15 @@ krew_enabled: false
 krew_root_dir: "/usr/local/krew"
 
 # Kube VIP
-kube_vip_enabled: false
-# kube_vip_arp_enabled: true
-# kube_vip_controlplane_enabled: true
-# kube_vip_address: 192.168.56.120
-# loadbalancer_apiserver:
-#   address: "{{ kube_vip_address }}"
-#   port: 6443
-# kube_vip_interface: eth0
-# kube_vip_services_enabled: false
+kube_vip_enabled: true
+kube_vip_arp_enabled: true
+kube_vip_controlplane_enabled: true
+kube_vip_address: 192.168.20.13
+loadbalancer_apiserver:
+  address: 192.168.20.13
+  port: 6443
+kube_vip_interface: eno1
+kube_vip_services_enabled: false
 # kube_vip_dns_mode: first
 # kube_vip_cp_detect: false
 # kube_vip_leasename: plndr-cp-lock

--- a/inventory/soycluster/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/soycluster/group_vars/k8s_cluster/k8s-cluster.yml
@@ -173,6 +173,7 @@ ndots: 2
 # remove_default_searchdomains: false
 # Can be coredns, coredns_dual, manual or none
 dns_mode: coredns
+dns_min_replicas: 2
 # Set manual server if using a custom cluster DNS server
 # manual_dns_server: 10.x.x.x
 # Explicit upstreams keep CoreDNS/NodeLocalDNS from forwarding public lookups to

--- a/inventory/soycluster/hosts.yml
+++ b/inventory/soycluster/hosts.yml
@@ -29,6 +29,8 @@ all:
     kube_control_plane:
       hosts:
         node-0:
+        node-1:
+        node-2:
     kube_node:
       hosts:
         node-0:
@@ -37,6 +39,8 @@ all:
     etcd:
       hosts:
         node-0:
+        node-1:
+        node-2:
     k8s_cluster:
       children:
         kube_control_plane:


### PR DESCRIPTION
## What changed
- Added node-1 and node-2 to `kube_control_plane` and `etcd` for the soycluster inventory.
- Enabled kube-vip ARP control-plane VIP at `192.168.20.13` on `eno1`.
- Set `dns_min_replicas: 2` so CoreDNS is not left as a single pod.

## Why
The worker/SSD stretch is already done, but the Kubernetes API and etcd were still node-0 only. This prepares the cluster to tolerate any one node being temporarily unavailable, apart from the known node-0 media disk and MQTT/gateway hardware exceptions.

## Validation
- `scripts/check-ha-stretch.sh --expect-ha --repo-only --vip 192.168.20.13` from the soyspray parent repo
- `source soyspray-venv/bin/activate && ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --syntax-check kubespray/cluster.yml` from the soyspray parent repo
- Verified `192.168.20.13` did not respond to ping and is not assigned to any current LoadBalancer service.