### PR TITLE
[codex] Support promoting workers to control plane

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
@@ -40,6 +40,26 @@
   debug:
     msg: "{{ kubeadm_already_run.stat.exists }}"
 
+- name: Check for kube-vip-created admin.conf directory
+  stat:
+    path: "{{ kube_config_dir }}/admin.conf"
+    get_attributes: false
+    get_checksum: false
+    get_mime: false
+  register: kubeadm_admin_conf_path
+  when:
+    - inventory_hostname != first_kube_control_plane
+    - kubeadm_already_run is not defined or not kubeadm_already_run.stat.exists
+
+- name: Remove kube-vip-created admin.conf directory
+  file:
+    path: "{{ kube_config_dir }}/admin.conf"
+    state: absent
+  when:
+    - inventory_hostname != first_kube_control_plane
+    - kubeadm_already_run is not defined or not kubeadm_already_run.stat.exists
+    - kubeadm_admin_conf_path.stat.isdir | default(false)
+
 - name: Reset cert directory
   shell: >-
     if [ -f /etc/kubernetes/manifests/kube-apiserver.yaml ]; then

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -12,7 +12,7 @@
 
 - name: Kubeadm | Check if kubeadm has already run
   stat:
-    path: "/var/lib/kubelet/config.yaml"
+    path: "{{ kube_manifest_dir }}/kube-apiserver.yaml"
     get_attributes: false
     get_checksum: false
     get_mime: false

--- a/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-vip.manifest.j2
@@ -137,5 +137,6 @@ spec:
   volumes:
   - hostPath:
       path: /etc/kubernetes/{{kube_vip_admin_conf}}
+      type: FileOrCreate
     name: kubeconfig
 status: {}


### PR DESCRIPTION
## What changed
- Detect an existing control plane by the API server static pod manifest instead of the worker kubelet config.
- Force the kube-vip kubeconfig hostPath to be a file.
- Remove the stale admin.conf directory case before joining a promoted worker as a control plane.

## Why
The soycluster HA stretch failed after etcd expansion because node-1 and node-2 were existing workers. Kubespray treated them as already-initialized control-plane nodes, then tried to inspect an API server certificate that did not exist yet. kube-vip also created /etc/kubernetes/admin.conf as a directory before kubeadm could write the real kubeconfig.

## Validation
- source soyspray-venv/bin/activate && ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --syntax-check kubespray/cluster.yml