### PR TITLE
[codex] Clean local API proxies before kube-vip

### DIFF
--- a/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
+++ b/roles/kubernetes/node/tasks/loadbalancer/kube-vip.yml
@@ -43,6 +43,14 @@
     - inventory_hostname == groups['kube_control_plane'] | first
     - (stat_kube_vip_super_admin.stat.exists and stat_kube_vip_super_admin.stat.isreg) or (not kubeadm_already_run.stat.exists )
 
+- name: Kube-vip | Cleanup potentially deployed local API proxies
+  file:
+    path: "{{ kube_manifest_dir }}/{{ item }}"
+    state: absent
+  loop:
+    - nginx-proxy.yml
+    - haproxy.yml
+
 - name: Kube-vip | Write static pod
   template:
     src: manifests/kube-vip.manifest.j2


### PR DESCRIPTION
## What changed
- remove stale local API proxy static pod manifests before writing kube-vip
- covers both nginx-proxy and haproxy manifests from earlier local load-balancer modes

## Why
Promoting existing workers to control-plane can fail kubeadm preflight when an old nginx-proxy static pod is still binding 127.0.0.1:6443. The kube-vip path should clean that stale proxy the same way the other local load-balancer paths clean each other up.

## Validation
- ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --syntax-check kubespray/cluster.yml