### PR TITLE
[codex] Remove empty admin.conf before control-plane join

### DIFF
--- a/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-secondary.yml
@@ -60,6 +60,16 @@
     - kubeadm_already_run is not defined or not kubeadm_already_run.stat.exists
     - kubeadm_admin_conf_path.stat.isdir | default(false)
 
+- name: Remove kube-vip-created empty admin.conf file
+  file:
+    path: "{{ kube_config_dir }}/admin.conf"
+    state: absent
+  when:
+    - inventory_hostname != first_kube_control_plane
+    - kubeadm_already_run is not defined or not kubeadm_already_run.stat.exists
+    - kubeadm_admin_conf_path.stat.isreg | default(false)
+    - kubeadm_admin_conf_path.stat.size | default(1) == 0
+
 - name: Check if kubelet is already configured for worker promotion
   stat:
     path: "{{ kube_config_dir }}/kubelet.conf"


### PR DESCRIPTION
## What changed
- remove an empty `admin.conf` placeholder before joining a secondary control-plane node
- keep the existing directory cleanup and scope the new cleanup to nodes that have not already joined

## Why
When kube-vip mounts `admin.conf` with `FileOrCreate`, existing worker promotion can leave a zero-byte file. `kubeadm join --control-plane` then tries to generate kubeconfigs and fails because the existing `admin.conf` has no current context.

## Validation
- ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --syntax-check kubespray/cluster.yml