### PR TITLE
[codex] Reconcile DNS autoscaler configmap

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/dns-autoscaler-configmap.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/dns-autoscaler-configmap.yml.j2
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dns-autoscaler{{ coredns_ordinal_suffix }}
+  namespace: kube-system
+  labels:
+    k8s-app: dns-autoscaler{{ coredns_ordinal_suffix }}
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  linear: '{"preventSinglePointFailure":{{ dns_prevent_single_point_failure }},"coresPerReplica":{{ dns_cores_per_replica }},"nodesPerReplica":{{ dns_nodes_per_replica }},"min":{{ dns_min_replicas }}}'

--- a/roles/kubernetes-apps/ansible/vars/main.yml
+++ b/roles/kubernetes-apps/ansible/vars/main.yml
@@ -1,6 +1,7 @@
 ---
 dns_autoscaler_manifests:
 - dns-autoscaler-sa.yml.j2
+- dns-autoscaler-configmap.yml.j2
 - dns-autoscaler.yml.j2
 - dns-autoscaler-clusterrole.yml.j2
 - dns-autoscaler-clusterrolebinding.yml.j2


### PR DESCRIPTION
## What changed
- Add a managed dns-autoscaler ConfigMap template.
- Apply it with the existing CoreDNS autoscaler manifests so dns_min_replicas and preventSinglePointFailure reconcile after inventory changes.

## Why
The live cluster kept an old dns-autoscaler ConfigMap with min:1 after the control-plane stretch, so CoreDNS stayed at one replica even though inventory requested two.

## Validation
- ansible-playbook -i kubespray/inventory/soycluster/hosts.yml --syntax-check kubespray/cluster.yml