### PR TITLE
Fix apiserver VIP certificate SANs

### DIFF
--- a/inventory/soycluster/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/soycluster/group_vars/k8s_cluster/k8s-cluster.yml
@@ -317,7 +317,11 @@ default_kubelet_config_dir: "{{ kube_config_dir }}/dynamic_kubelet_dir"
 
 ## Supplementary addresses that can be added in kubernetes ssl keys.
 ## That can be useful for example to setup a keepalived virtual IP
-# supplementary_addresses_in_ssl_keys: [10.0.0.1, 10.0.0.2, 10.0.0.3]
+supplementary_addresses_in_ssl_keys:
+  - 192.168.20.13
+  - 192.168.20.10
+  - 192.168.20.11
+  - 192.168.20.12
 
 ## Running on top of openstack vms with cinder enabled may lead to unschedulable pods due to NoVolumeZoneConflict restriction in kube-scheduler.
 ## See https://github.com/kubernetes-sigs/kubespray/issues/2141

--- a/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/control-plane/tasks/kubeadm-setup.yml
@@ -166,6 +166,7 @@
     {{ bin_dir }}/kubeadm
     init phase certs apiserver
     --config={{ kube_config_dir }}/kubeadm-config.yaml
+  notify: Control plane | Restart apiserver
   when:
     - kubeadm_already_run.stat.exists
     - apiserver_sans_ip_check.changed or apiserver_sans_host_check.changed


### PR DESCRIPTION
## Summary
- add the Kubernetes API VIP and all control-plane node IPs to the soycluster apiserver certificate SAN list
- restart apiserver containers when Kubespray regenerates apiserver certificates

## Root cause
After the API VIP moved to node-1, kube-proxy rejected that node's apiserver certificate because it did not include 192.168.20.13. That broke ClusterIP routing to the in-cluster API and cascaded into networking/storage/app failures.

## Validation
- ansible-inventory confirms supplementary_addresses_in_ssl_keys includes 192.168.20.13 and all node IPs
- scripts/check-ha-stretch.sh --expect-ha --repo-only --vip 192.168.20.13
- ansible-playbook --syntax-check kubespray/cluster.yml
- targeted Kubespray apply for control-plane,kube-proxy completed successfully
- all nodes Ready, API readyz passed, 106 pods Running
