### PR TITLE
Keep Authentik issuer on the cluster ingress

### DIFF
--- a/inventory/soycluster/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/inventory/soycluster/group_vars/k8s_cluster/k8s-cluster.yml
@@ -182,6 +182,9 @@ dns_min_replicas: 2
 upstream_dns_servers:
   - 1.1.1.1
   - 9.9.9.9
+# Keep the public Authentik issuer on the LAN ingress for in-cluster clients.
+dns_etchosts: |
+  192.168.20.20 auth.soyspray.vip
 # Enable nodelocal dns cache
 enable_nodelocaldns: true
 enable_nodelocaldns_secondary: false


### PR DESCRIPTION
## Outcome

CoreDNS and NodeLocalDNS resolve auth.soyspray.vip to the LAN ingress address. In-cluster OIDC clients no longer follow the router Tailscale answer.

## Change

- Add the Authentik hostname to dns_etchosts.
- Preserve the existing lan and soyspray.vip NodeLocalDNS forwarding rules.

## Verification

- Parsed the inventory as YAML.
- Asserted the exact hosts entry and the existing external-zone mapping.
- yamllint passed for the inventory file.

Related to kpoxo6op/soyspray#183.